### PR TITLE
doc: Document traversal interfaces and classes

### DIFF
--- a/src/main/java/org/terasology/blockNetwork/traversal/BreadthFirstTraversal.java
+++ b/src/main/java/org/terasology/blockNetwork/traversal/BreadthFirstTraversal.java
@@ -24,5 +24,13 @@ package org.terasology.blockNetwork.traversal;
  * @param <V> Value passed from node visited into nodes that are outgoing from that node.
  */
 public interface BreadthFirstTraversal<T, U, V> {
+    /**
+     * Traverses the given node in the graph.
+     * This method is invoked for each node in a traversal as directed by the traversal definition and the traversal result.
+     * 
+     * @param node The type of nodes in the graph.
+     * @param parentValue The value passed from the parent node in the traversal into this node.
+     * @return The result of the node traversal.
+     */
     TraversalResult<T, U, V> visitNode(T node, V parentValue);
 }

--- a/src/main/java/org/terasology/blockNetwork/traversal/BreadthFirstTraversal.java
+++ b/src/main/java/org/terasology/blockNetwork/traversal/BreadthFirstTraversal.java
@@ -28,7 +28,7 @@ public interface BreadthFirstTraversal<T, U, V> {
      * Traverses the given node in the graph.
      * This method is invoked for each node in a traversal as directed by the traversal definition and the traversal result.
      * 
-     * @param node The type of nodes in the graph.
+     * @param node The node to traverse.
      * @param parentValue The value passed from the parent node in the traversal into this node.
      * @return The result of the node traversal.
      */

--- a/src/main/java/org/terasology/blockNetwork/traversal/BreadthFirstTraversalWithPath.java
+++ b/src/main/java/org/terasology/blockNetwork/traversal/BreadthFirstTraversalWithPath.java
@@ -27,5 +27,14 @@ import java.util.List;
  * @param <V> Value passed from node visited into nodes that are outgoing from that node.
  */
 public interface BreadthFirstTraversalWithPath<T, U, V> {
+    /**
+     * Traverses the given node in the graph.
+     * This method is invoked for each node in a traversal as directed by the traversal definition and the traversal result.
+     * 
+     * @param node The type of nodes in the graph.
+     * @param parentValue The value passed from the parent node in the traversal into this node.
+     * @param path The traversal path from the start node up to the node currently being traversed.
+     * @return The result of the node traversal.
+     */
     TraversalResult<T, U, V> visitNode(T node, V parentValue, List<T> path);
 }

--- a/src/main/java/org/terasology/blockNetwork/traversal/BreadthFirstTraversalWithPath.java
+++ b/src/main/java/org/terasology/blockNetwork/traversal/BreadthFirstTraversalWithPath.java
@@ -31,7 +31,7 @@ public interface BreadthFirstTraversalWithPath<T, U, V> {
      * Traverses the given node in the graph.
      * This method is invoked for each node in a traversal as directed by the traversal definition and the traversal result.
      * 
-     * @param node The type of nodes in the graph.
+     * @param node The node to traverse.
      * @param parentValue The value passed from the parent node in the traversal into this node.
      * @param path The traversal path from the start node up to the node currently being traversed.
      * @return The result of the node traversal.

--- a/src/main/java/org/terasology/blockNetwork/traversal/TraversalResult.java
+++ b/src/main/java/org/terasology/blockNetwork/traversal/TraversalResult.java
@@ -18,10 +18,33 @@ package org.terasology.blockNetwork.traversal;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
 
+/**
+ * The result of a node traversal performed on a graph. It contains a flag to stop the traversal, a predicate for selecting consequent 
+ * nodes to be traversed, the returned result of the traversal, and the value propagated through the traversal.
+ * 
+ * @param <T> Type of nodes in the graph.
+ * @param <U> Return value type from the traversal.
+ * @param <V> Value passed from node visited into nodes that are outgoing from that node.
+ */
 public final class TraversalResult<T, U, V> {
+    /**
+     * A flag specifying whether to stop the traversal or not.
+     */
     public final boolean stopTraversal;
+    
+    /**
+     * The predicate that filters or selects the nodes that shall be traversed in the next step.
+     */
     public Predicate<T> predicate;
+    
+    /**
+     * The result of the node traversal.
+     */
     public final U result;
+    
+    /**
+     * The value propagated through the node traversal.
+     */
     public final V value;
 
     private TraversalResult(boolean stopTraversal, Predicate<T> predicate, U result, V value) {

--- a/src/main/java/org/terasology/blockNetwork/traversal/TraversalResult.java
+++ b/src/main/java/org/terasology/blockNetwork/traversal/TraversalResult.java
@@ -27,24 +27,16 @@ import com.google.common.base.Predicates;
  * @param <V> Value passed from node visited into nodes that are outgoing from that node.
  */
 public final class TraversalResult<T, U, V> {
-    /**
-     * A flag specifying whether to stop the traversal or not.
-     */
+    // A flag specifying whether to stop the traversal or not.
     public final boolean stopTraversal;
     
-    /**
-     * The predicate that filters or selects the nodes that shall be traversed in the next step.
-     */
+    // The predicate that filters or selects the nodes that shall be traversed in the next step.
     public Predicate<T> predicate;
     
-    /**
-     * The result of the node traversal.
-     */
+    // The result of the node traversal.
     public final U result;
     
-    /**
-     * The value propagated through the node traversal.
-     */
+    // The value propagated through the node traversal.
     public final V value;
 
     private TraversalResult(boolean stopTraversal, Predicate<T> predicate, U result, V value) {


### PR DESCRIPTION
Adds missing documentation to classes and interfaces in the `org.terasology.blockNetwork.traversal` package.

## Documents
- `TraversalResult` and its fields
- `BreadthFirstTraversal` methods
- `BreadthFirstTraversalWithPath` methods